### PR TITLE
Support ArrayExpectation as root-expectation

### DIFF
--- a/src/main/groovy/com/zendesk/jazon/spock/JazonSpockAdapter.groovy
+++ b/src/main/groovy/com/zendesk/jazon/spock/JazonSpockAdapter.groovy
@@ -17,19 +17,27 @@ class JazonSpockAdapter {
     }
 
     boolean matches(Map jsonAsMap) {
+        return match(jsonAsMap, parsed(json) as Map<String, Object>)
+    }
+
+    boolean matches(List jsonAsList) {
+        return match(jsonAsList, parsed(json) as List<Object>)
+    }
+
+    private boolean match(Object expected, Object actual) {
         def matchResult = matcherFactory.matcher()
-                .expected(jsonAsMap)
-                .actual(parsed(json))
-                .match();
+                .expected(expected)
+                .actual(actual)
+                .match()
         if (matchResult.ok()) {
             return true
         }
         throw new AssertionError("\n-----------------------------------\nJSON MISMATCH:\n${matchResult.message()}\n-----------------------------------\n")
     }
 
-    private static Map<String, Object> parsed(String jsonAsString) {
+    private static parsed(String jsonAsString) {
         new JsonSlurper()
-                .parse(jsonAsString.getBytes()) as Map<String, Object>
+                .parse(jsonAsString.getBytes())
     }
 
     static JazonSpockAdapter jazon(String json) {

--- a/src/main/java/com/zendesk/jazon/Matcher.java
+++ b/src/main/java/com/zendesk/jazon/Matcher.java
@@ -5,8 +5,6 @@ import com.zendesk.jazon.actual.ActualFactory;
 import com.zendesk.jazon.expectation.ExpectationFactory;
 import com.zendesk.jazon.expectation.JsonExpectation;
 
-import java.util.Map;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Matcher {
@@ -29,8 +27,8 @@ public class Matcher {
         return this;
     }
 
-    public Matcher expected(Map<String, Object> expectationMap) {
-        this.expectation = expectationFactory.expectation(expectationMap);
+    public Matcher expected(Object expectation) {
+        this.expectation = expectationFactory.expectation(expectation);
         return this;
     }
 
@@ -39,8 +37,8 @@ public class Matcher {
         return this;
     }
 
-    public Matcher actual(Map<String, Object> jsonAsMap) {
-        this.actual = actualFactory.actual(jsonAsMap);
+    public Matcher actual(Object actual) {
+        this.actual = actualFactory.actual(actual);
         return this;
     }
 }

--- a/src/test/groovy/com/zendesk/jazon/ExampleSpec.groovy
+++ b/src/test/groovy/com/zendesk/jazon/ExampleSpec.groovy
@@ -24,4 +24,15 @@ class ExampleSpec extends Specification {
                 wegorz: { it.startsWith('ele') }
         ])
     }
+
+    def "array can be root JSON: success"() {
+        expect:
+        jazon('["platypus", "narwhal"]').matches(['platypus', 'narwhal'])
+    }
+
+    @FailsWith(AssertionError)
+    def "array can be root JSON: fails"() {
+        expect:
+        jazon('["platypus", "narwhal"]').matches(['platypus', 'lynx'])
+    }
 }

--- a/src/test/groovy/com/zendesk/jazon/MatcherForGroovySpec.groovy
+++ b/src/test/groovy/com/zendesk/jazon/MatcherForGroovySpec.groovy
@@ -47,6 +47,7 @@ class MatcherForGroovySpec extends Specification {
         then:
         !result.ok()
         result.mismatch().expectationMismatch() == PredicateMismatch.INSTANCE
+        result.mismatch().path() == '$.a'
 
         where:
         stringToMatch << [
@@ -56,5 +57,18 @@ class MatcherForGroovySpec extends Specification {
                 'dagger',
                 'refrigerator',
         ]
+    }
+
+    def "predicate expectation can be root"() {
+        when:
+        def result = matcherFactory.matcher()
+                .expected({ it ==~ 'dig.*'})
+                .actual('refrigerator')
+                .match()
+
+        then:
+        !result.ok()
+        result.mismatch().expectationMismatch() == PredicateMismatch.INSTANCE
+        result.mismatch().path() == '$'
     }
 }


### PR DESCRIPTION
Allow Matcher to take any expectation as root-expectation - not only ObjectExpectation.
Allow Map and List (Object and Array) to be root-expectations in JazonSpockAdapter.