### PR TITLE
Fix printing of actual Objects and Arrays

### DIFF
--- a/jazon-core/src/main/java/com/zendesk/jazon/actual/ActualJsonArray.java
+++ b/jazon-core/src/main/java/com/zendesk/jazon/actual/ActualJsonArray.java
@@ -30,11 +30,11 @@ public class ActualJsonArray implements Actual {
 
     @Override
     public String toString() {
-        return "[" + String.join(", ", strings(list)) + "]";
+        return "[" + String.join(", ", strings()) + "]";
     }
 
-    private static List<String> strings(List<Actual> actuals) {
-        return actuals.stream()
+    private List<String> strings() {
+        return list.stream()
                 .map(Objects::toString)
                 .collect(toList());
     }

--- a/jazon-core/src/main/java/com/zendesk/jazon/actual/ActualJsonArray.java
+++ b/jazon-core/src/main/java/com/zendesk/jazon/actual/ActualJsonArray.java
@@ -3,14 +3,14 @@ package com.zendesk.jazon.actual;
 import com.zendesk.jazon.MatchResult;
 import com.zendesk.jazon.expectation.JsonExpectation;
 import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 import java.util.List;
+import java.util.Objects;
 
 import static com.zendesk.jazon.util.Preconditions.checkNotNull;
 import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
 
-@ToString
 @EqualsAndHashCode
 public class ActualJsonArray implements Actual {
     private final List<Actual> list;
@@ -26,5 +26,16 @@ public class ActualJsonArray implements Actual {
     @Override
     public MatchResult accept(JsonExpectation expectation, String path) {
         return expectation.match(this, path);
+    }
+
+    @Override
+    public String toString() {
+        return "[" + String.join(", ", strings(list)) + "]";
+    }
+
+    private static List<String> strings(List<Actual> actuals) {
+        return actuals.stream()
+                .map(Objects::toString)
+                .collect(toList());
     }
 }

--- a/jazon-core/src/main/java/com/zendesk/jazon/actual/ActualJsonObject.java
+++ b/jazon-core/src/main/java/com/zendesk/jazon/actual/ActualJsonObject.java
@@ -3,16 +3,15 @@ package com.zendesk.jazon.actual;
 import com.zendesk.jazon.MatchResult;
 import com.zendesk.jazon.expectation.JsonExpectation;
 import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.zendesk.jazon.util.Preconditions.checkNotNull;
 import static java.util.Collections.unmodifiableMap;
 
-@ToString
 @EqualsAndHashCode
 public class ActualJsonObject implements Actual {
     private final Map<String, Actual> map;
@@ -40,5 +39,19 @@ public class ActualJsonObject implements Actual {
 
     public int size() {
         return map.size();
+    }
+
+    @Override
+    public String toString() {
+        if (map.isEmpty()) {
+            return "{}";
+        }
+        return "{" + fields() + "}";
+    }
+
+    private String fields() {
+        return map.entrySet().stream()
+                .map(e -> String.format("\"%s\": %s", e.getKey(), e.getValue()))
+                .collect(Collectors.joining(", "));
     }
 }

--- a/jazon-core/src/main/java/com/zendesk/jazon/actual/GsonActualFactory.java
+++ b/jazon-core/src/main/java/com/zendesk/jazon/actual/GsonActualFactory.java
@@ -3,6 +3,7 @@ package com.zendesk.jazon.actual;
 import com.google.gson.*;
 
 import java.math.BigDecimal;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -39,7 +40,9 @@ public class GsonActualFactory implements ActualFactory<String> {
                 .collect(
                         toMap(
                                 Map.Entry::getKey,
-                                e -> this.fromJsonElement(e.getValue())
+                                e -> this.fromJsonElement(e.getValue()),
+                                (a, b) -> a,
+                                LinkedHashMap::new
                         )
                 );
         return new ActualJsonObject(map);

--- a/jazon-core/src/main/java/com/zendesk/jazon/actual/ObjectsActualFactory.java
+++ b/jazon-core/src/main/java/com/zendesk/jazon/actual/ObjectsActualFactory.java
@@ -1,5 +1,6 @@
 package com.zendesk.jazon.actual;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,7 +33,9 @@ public class ObjectsActualFactory implements ActualFactory<Object> {
                 .collect(
                         toMap(
                                 Map.Entry::getKey,
-                                e -> actual(e.getValue())
+                                e -> actual(e.getValue()),
+                                (a, b) -> a,
+                                LinkedHashMap::new
                         )
                 );
         return new ActualJsonObject(map);

--- a/jazon-core/src/test/groovy/com/zendesk/jazon/MessagesSpec.groovy
+++ b/jazon-core/src/test/groovy/com/zendesk/jazon/MessagesSpec.groovy
@@ -157,6 +157,55 @@ class MessagesSpec extends Specification {
         print result
     }
 
+    def "ordered array expectation: unexpected element as object"() {
+        given:
+        def expected = [
+                items: [
+                    [firstname: 'Jack', lastname: 'Bauer'],
+                    [firstname: 'Franz', lastname: 'Beckenbauer']
+                ]
+        ]
+        def actual = [
+                items: [
+                    [firstname: 'Jack', lastname: 'Bauer'],
+                    [firstname: 'Franz', lastname: 'Beckenbauer'],
+                    [firstname: 'Oliver', lastname: 'Twist', position: [x: 1, y: 1]]
+                ]
+        ]
+
+        when:
+        def result = match(expected, actual)
+
+        then:
+        result.message() == 'Mismatch at path: \$.items\nArray contains unexpected items: [{"firstname": "Oliver", "lastname": "Twist", "position": {"x": 1, "y": 1}}]'
+        print result
+    }
+
+    def "ordered array expectation: unexpected element as array"() {
+        given:
+        def expected = [
+                items: [
+                        ['red', 'green', 'blue'],
+                        ['cyan', 'magenta', 'yellow']
+                ]
+        ]
+        def actual = [
+                items: [
+                        ['red', 'green', 'blue'],
+                        ['cyan', 'magenta', 'yellow'],
+                        ['huehue', 'hue', 'alpha', 'saturn', 'jupiter'],
+                        ['finito']
+                ]
+        ]
+
+        when:
+        def result = match(expected, actual)
+
+        then:
+        result.message() == 'Mismatch at path: \$.items\nArray contains unexpected items: [["huehue", "hue", "alpha", "saturn", "jupiter"], ["finito"]]'
+        print result
+    }
+
     MatchResult match(Map expected, Map actual) {
         matcherFactory.matcher()
                 .expected(expected)


### PR DESCRIPTION
Until now it used to be like that:
```
-----------------------------------
JSON MISMATCH:
Mismatch at path: $.0.items
Array contains unexpected items: [ActualJsonObject(map={orderId=28, name="Kek", id=57}), ActualJsonObject(map={orderId=28, name="Lel", id=58})]
-----------------------------------
```

With this changes it should be something like:
```
-----------------------------------
JSON MISMATCH:
Mismatch at path: $.0.items
Array contains unexpected items: [{orderId: 28, name: "Kek", id: 57}), {orderId: 28, name: "Lel", id: 58})]
-----------------------------------
```