### PR TITLE
Bump GSON version to `2.9.1` to get rid of a vulnerability

### DIFF
--- a/jazon-core/build.gradle
+++ b/jazon-core/build.gradle
@@ -6,7 +6,7 @@ ext {
 apply from: '../gradle/publishing.gradle'
 
 dependencies {
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
 
     compileOnly 'org.projectlombok:lombok:1.18.12'
     annotationProcessor 'org.projectlombok:lombok:1.18.12'


### PR DESCRIPTION
This is the vuln: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647