### PR TITLE
Bumping gson to gson:2.10.1 in jazon-core to support gson.Strictness

### DIFF
--- a/jazon-core/build.gradle
+++ b/jazon-core/build.gradle
@@ -6,7 +6,7 @@ ext {
 apply from: '../gradle/publishing.gradle'
 
 dependencies {
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
 
     compileOnly 'org.projectlombok:lombok:1.18.12'
     annotationProcessor 'org.projectlombok:lombok:1.18.12'


### PR DESCRIPTION
Description
gson.Strictness was introduced in gson : 2.10.0
to use the same, updating gson from 2.9.1 to 2.10.1
