### PR TITLE
removed unneccessary properties from workflow file

### DIFF
--- a/.github/workflows/dependabot-workflow.yml
+++ b/.github/workflows/dependabot-workflow.yml
@@ -6,15 +6,6 @@ on:
 permissions:
   contents: write
 
-env:
-  "ARTIFACTORY_PASSWORD": "${{ secrets.SELL_ARTIFACTORY_PASSWORD }}"
-  "ARTIFACTORY_USER": "${{ secrets.SELL_ARTIFACTORY_USER }}"
-  "BUILD_DOCKER_IMAGE": "713408432298.dkr.ecr.us-west-2.amazonaws.com/base/zendesk/sell-docker-images-base/sell-corretto-build"
-  "BUILD_DOCKER_IMAGETAG": "17-jammy"
-  "ZDREPO_ARTIFACTORY_API_KEY": "${{ secrets.ARTIFACTORY_API_KEY }}"
-  "ZDREPO_ARTIFACTORY_USERNAME": "${{ secrets.ARTIFACTORY_USERNAME }}"
-  "BASE_MAVEN_REPO_ALL_URL": "${{ secrets.BASE_MAVEN_REPO_ALL_URL || 'https://zdrepo.jfrog.io/zdrepo/zen-libs-m2/' }}"
-
 jobs:
   update-dependency-graph:
     runs-on: [self-hosted, zendesk-stable]

--- a/.github/workflows/dependabot-workflow.yml
+++ b/.github/workflows/dependabot-workflow.yml
@@ -1,11 +1,19 @@
 name: Update dependency graph
 
 on:
-  push:
-    branches: [ 'master' ]
+  pull_request:
 
 permissions:
   contents: write
+
+env:
+  "ARTIFACTORY_PASSWORD": "${{ secrets.SELL_ARTIFACTORY_PASSWORD }}"
+  "ARTIFACTORY_USER": "${{ secrets.SELL_ARTIFACTORY_USER }}"
+  "BUILD_DOCKER_IMAGE": "713408432298.dkr.ecr.us-west-2.amazonaws.com/base/zendesk/sell-docker-images-base/sell-corretto-build"
+  "BUILD_DOCKER_IMAGETAG": "17-jammy"
+  "ZDREPO_ARTIFACTORY_API_KEY": "${{ secrets.ARTIFACTORY_API_KEY }}"
+  "ZDREPO_ARTIFACTORY_USERNAME": "${{ secrets.ARTIFACTORY_USERNAME }}"
+  "BASE_MAVEN_REPO_ALL_URL": "${{ secrets.BASE_MAVEN_REPO_ALL_URL || 'https://zdrepo.jfrog.io/zdrepo/zen-libs-m2/' }}"
 
 jobs:
   update-dependency-graph:
@@ -20,39 +28,3 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-
-      - name: Fix maven-repo.gradle
-        run: |
-          # Display content of the problematic file
-          echo "Current content of maven-repo.gradle:"
-          cat gradle/maven-repo.gradle
-          
-          # Create a temporary file with fixes
-          cat > gradle/maven-repo.gradle.new << 'EOL'
-          // Define the property as an extension property
-          ext {
-              baseMavenRepoAllUrl = System.getenv('BASE_MAVEN_REPO_ALL_URL') ?: "https://zdrepo.jfrog.io/zdrepo/zen-libs-m2/"
-          }
-          
-          // Rest of the original file content can follow
-          // ... keep any other needed content from the original file
-          EOL
-          
-          # Replace the original file
-          mv gradle/maven-repo.gradle.new gradle/maven-repo.gradle
-          
-          # Verify the change
-          echo "Updated content of maven-repo.gradle:"
-          cat gradle/maven-repo.gradle
-
-      - name: Print Gradle info
-        run: |
-          ./gradlew --version
-          ./gradlew properties
-
-      - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v4.3.0
-        with:
-          gradle-build-root: .
-          gradle-build-module: .
-          gradle-build-configuration: implementation


### PR DESCRIPTION
## Description
- We added dependabot-workflow with previous PR: https://github.com/zendesk/jazon/pull/36.
- But after merging, there was an [error](https://github.com/zendesk/jazon/actions/runs/14891068924) as this workflow needs `maven-repo.gradle` file.
- This PR is created to fix this issue.

## Risks
- Level: None